### PR TITLE
Added Klaus2m5's mixed case mod

### DIFF
--- a/src/basic.s
+++ b/src/basic.s
@@ -39,6 +39,7 @@
 ;      5.5     garbage collection may cause an overlap with temporary strings
 ;      5.6     floating point multiply rounding bug
 ;      5.7     VAL() may cause string variables to be trashed
+;      6.0     add klaus2m5's mixed case mode. (https://github.com/Klaus2m5/6502_EhBASIC_V2.22/blob/master/mixed_case_keywords_mod.txt)
 
 .org     $D000
 

--- a/src/lang.s
+++ b/src/lang.s
@@ -763,7 +763,13 @@ LAB_13A6:
 LAB_13AC:
       LDA   Ibuffs,X          ; get byte from input buffer
       BEQ   LAB_13EC          ; if null save byte then exit
-
+      CMP   #'{'              ; convert lower to upper case
+      BCS   LAB_13EC          ; is above lower case
+      CMP   #'a'
+      BCC   PATCH_LC          ; is below lower case
+      AND   #$DF              ; mask lower case bit
+      
+PATCH_LC:
       CMP   #'_'              ; compare with "_"
       BCS   LAB_13EC          ; if >= go save byte then continue crunching
 
@@ -798,7 +804,7 @@ LAB_13D0:
       CMP   (ut2_pl),Y        ; compare with keyword first character table byte
       BEQ   LAB_13D1          ; go do word_table_chr if match
 
-      BCC   LAB_13EA          ; if < keyword first character table byte go restore
+      BCC   PATCH_LC2         ; if < keyword first character table byte go restore
                               ; Y and save to crunched
 
       INY                     ; else increment pointer
@@ -826,7 +832,8 @@ LAB_13D8:
       BMI   LAB_13EA          ; all bytes matched so go save token
 
       INX                     ; next buffer byte
-      CMP   Ibuffs,X          ; compare with byte from input buffer
+      EOR     Ibuffs,x        ; check bits against table
+      AND     #$DF            ; DF masks the upper/lower case bit
       BEQ   LAB_13D6          ; go compare next if match
 
       BNE   LAB_1417          ; branch if >< (not found keyword)
@@ -888,7 +895,7 @@ LAB_141B:
 
       LDA   (ut2_pl),Y        ; get byte from keyword table
       BNE   LAB_13D8          ; go test next word if not zero byte (end of table)
-
+PATCH_LC2:
                               ; reached end of table with no match
       LDA   Ibuffs,X          ; restore byte from input buffer
       BPL   LAB_13EA          ; branch always (all bytes in buffer are $00-$7F)


### PR DESCRIPTION
Add the minor changes published by Klaus2m5 here: https://github.com/Klaus2m5/6502_EhBASIC_V2.22/blob/master/mixed_case_keywords_mod.txt

With this patch, keywords can be entered in mixed case.
They are translated to UPPERCASE in the program listing.

Variables will be affected thusly:

```basic
10 a=10
20 A=20
30 print a
40 print A
run
 10
 20

Ready
list

10 a=10
20 A=20
30 PRINT a
40 PRINT A

Ready
```