### PR TITLE
Initial plotting enhancements offered for the RP6502 Picocomputer's EhBASIC.

### DIFF
--- a/BarnsleyFern.txt
+++ b/BarnsleyFern.txt
@@ -6,9 +6,9 @@
  
  50 REM Addresses for our four new functions from mapfile:
  55 LET      HGR = $E8B2  : REM F_HGR->init_bitmap_graphics()
- 60 LET    HPLOT = $E8B6  : REM F_HPLOT->draw_pixel()
- 65 LET TEXTMODE = $E8F2  : REM F_TEXT->init_console_text()
- 70 LET     HOME = $E8F6  : REM F_CLS->cls()
+ 60 LET    HPLOT = $E8BA  : REM F_HPLOT->draw_pixel()
+ 65 LET TEXTMODE = $E8F6  : REM F_TEXT->init_console_text()
+ 70 LET     HOME = $E8FA  : REM F_CLS->cls()
  75 LET      CLS = HOME   : REM cls()
  82 LET    GREEN = 10     : REM Green ON EHBASIC HPLOT 
 
@@ -23,7 +23,7 @@
 180  YX(4) =   0.26 : YY(4) = 0.24
 190  LET Y(4) = 0.44
 200  REM HGR :I =  PEEK (49234) : REM Applesoft HI-RES GRAPHICS NO TEXT
-202  CALL HGR : REM EhBASIC 
+202  CALL HGR,$FF : REM EhBASIC $FF means 320H x 240V x 4bpp
 210  REM HCOLOR= 1 : REM GREEN ON APPLE-II 
 220  LET X = 0    : Y = 0
 225  LET Xint = 0 : Yint = 0 : REM Applesoft has integer vars X% and Y% 
@@ -44,7 +44,8 @@
 
 320 REM  Y%   = 192 - Y * 19.1           : REM Original Applesoft
 322 REM  Yint = INT( 192 - (Y * 19.1) )
-324      Yint = INT( 180 - (Y * 17.9) )
+324 REM  Yint = INT( 180 - (Y * 17.9) ) : REM use for EhBASIC 320Hx180V mode
+325      Yint = INT( 240 - (Y * 23.9) ) : REM use for EhBASIC 320Hx240V mode
 
 330      REM  HPLOT X% * 2 + 1,Y%          : REM Applesoft
 333      IF Xint > 127 THEN LET Xint = 127 : REM Ensure HPLOT's x var is < 255

--- a/BarnsleyFern.txt
+++ b/BarnsleyFern.txt
@@ -1,0 +1,54 @@
+ 10 REM BARNSLEY FERN
+ 15 REM FROM: ROSETTA CODE WEBSITE 
+ 20 REM Conversion from Applesoft BASIC to EHBASIC on RP6502
+ 25 REM Applesoft screen is 280h x 192v
+ 30 REM Our early rev rpg6502 EhBASIC screen is 320h x 180v 
+ 
+ 50 REM Addresses for our four new functions from mapfile:
+ 55 LET      HGR = $E8B2  : REM F_HGR->init_bitmap_graphics()
+ 60 LET    HPLOT = $E8B6  : REM F_HPLOT->draw_pixel()
+ 65 LET TEXTMODE = $E8F2  : REM F_TEXT->init_console_text()
+ 70 LET     HOME = $E8F6  : REM F_CLS->cls()
+ 75 LET      CLS = HOME   : REM cls()
+ 82 LET    GREEN = 10     : REM Green ON EHBASIC HPLOT 
+
+100  LET YY(1) = 0.16
+110  XX(2) =    0.85 : XY(2) = 0.04
+120  YX(2) =   -0.04 : YY(2) = 0.85
+130  LET Y(2) = 1.6
+140  XX(3) = 0.20 : XY(3) =  -0.26
+150  YX(3) = 0.23 : YY(3) =   0.22
+160  LET Y(3) = 1.6
+170  XX(4) =  -0.15 : XY(4) = 0.28
+180  YX(4) =   0.26 : YY(4) = 0.24
+190  LET Y(4) = 0.44
+200  REM HGR :I =  PEEK (49234) : REM Applesoft HI-RES GRAPHICS NO TEXT
+202  CALL HGR : REM EhBASIC 
+210  REM HCOLOR= 1 : REM GREEN ON APPLE-II 
+220  LET X = 0    : Y = 0
+225  LET Xint = 0 : Yint = 0 : REM Applesoft has integer vars X% and Y% 
+230  FOR I = 1 TO 100000
+240  REM R =  INT(RND(1) * 100) : REM Applesoft
+242      R =  INT(RND(0) * 100) : REM EhBASIC
+250  REM F = (R < 7) + (R < 14) + 2 : REM in Applesoft true == 1
+251      F = 0-(R<7) - (R < 14) + 2 : REM in EhBASIC   true ==-1 
+260  REM F = F - (R = 99) : REM Applesoft
+261      F = F + (R = 99) : REM EhBASIC
+270      X = XX(F) * X + XY(F) * Y
+280      Y = YX(F) * X + YY(F) * Y
+290      Y = Y + Y(F)
+
+300 REM  X%   =  62 + X * 27.9           : REM Original Applesoft
+302      Xint = INT(  62 + (X * 27.9) )
+304 REM  Xint = INT(  70 + (X * 31.9) )
+
+320 REM  Y%   = 192 - Y * 19.1           : REM Original Applesoft
+322 REM  Yint = INT( 192 - (Y * 19.1) )
+324      Yint = INT( 180 - (Y * 17.9) )
+
+330      REM  HPLOT X% * 2 + 1,Y%          : REM Applesoft
+333      IF Xint > 127 THEN LET Xint = 127 : REM Ensure HPLOT's x var is < 255
+335      CALL HPLOT,(Xint*2),  Yint, GREEN : REM RP6502 EhBASIC  
+340  NEXT
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,4 +18,6 @@ target_sources(basic PRIVATE
     src/main.s
     src/min_mon.s
     src/usr.s
+    src/rp6502enhance.s
+    src/basgraf.c
 )

--- a/Mandelbrot.txt
+++ b/Mandelbrot.txt
@@ -1,0 +1,58 @@
+  1 REM Mandelbrot ported from Applesoft BASIC. Ref: Rosettacode.org
+  2 REM Addresses for our four new functions from mapfile:
+  3 LET      HGR = $E8B2  : REM F_HGR->init_bitmap_graphics()
+  4 LET    HPLOT = $E8B6  : REM F_HPLOT->draw_pixel()
+  5 LET TEXTMODE = $E8F2  : REM F_TEXT->init_console_text()
+  6 LET     HOME = $E8F6  : REM F_CLS->cls()
+  7 LET      CLS = HOME   : REM cls()
+  8 LET    WHITE = 15     : REM white ON EHBASIC HPLOT. 
+  9 REM EhBasic Colorrange 8(grey) 9(red) - 14(cyan) 15(wht); A2 ran 0(blk) - 7(wht2)
+
+10  CALL HGR
+20  XC = -0.5           : REM CENTER COORD X
+30  YC = 0              : REM   "      "   Y
+40  S = 2               : REM SCALE
+45  IT = 20             : REM ITERATIONS
+50  XR = S * (280 / 192): REM TOTAL RANGE OF X
+60  YR = S              : REM   "     "   "  Y
+70  X0 = XC - (XR/2)    : REM MIN VALUE OF X
+80  X1 = XC + (XR/2)    : REM MAX   "   "  X
+90  Y0 = YC - (YR/2)    : REM MIN   "   "  Y
+100 Y1 = YC + (YR/2)    : REM MAX   "   "  Y
+110 XM = XR / 279       : REM SCALING FACTOR FOR X
+120 YM = YR / 191       : REM    "      "     "  Y
+130 FOR YI = 0 TO 3     : REM INTERLEAVE
+140   REM FOR YS = 0+YI TO 188+YI STEP 4 : REM Y SCREEN COORDINATE
+141   FOR YS = 0+YI TO 176+YI STEP 4 : REM EhBASIC y-limit hack
+
+143   REM HCOLOR=3 : REM HPLOT 0,YS TO 279,YS : REM On A2: Clear-to-white 1st
+144   REM On pico6502, unnecessary to 1st clear each line to white
+145   REM FOR XJ = 0 TO 255 : CALL HPLOT,XJ,YS,WHITE : NEXT XJ
+
+150     REM FOR XS = 0 TO 278 STEP 2     : REM X SCREEN COORDINATE
+151     FOR XS = 0 TO 254 STEP 2         : REM EhBASIC x-limit hack
+170       X = XS * XM + X0  : REM TRANSL SCREEN TO TRUE X
+180       Y = YS * YM + Y0  : REM TRANSL SCREEN TO TRUE Y
+190       ZX = 0
+200       ZY = 0
+210       XX = 0
+220       YY = 0
+230       FOR I = 0 TO IT
+240         ZY = 2 * ZX * ZY + Y
+250         ZX = XX - YY + X
+260         XX = ZX * ZX
+270         YY = ZY * ZY
+280         C = IT-I
+290         IF XX+YY >= 4 GOTO 301
+300       NEXT I
+301       IF C >= 8 THEN C = C - 8 : GOTO 301
+
+309       IF C=0 THEN LET C=-8 :REM EhBASIC hack, force grey->black
+310       REM HCOLOR = C : REM HPLOT XS, YS TO XS+1, YS
+311       CALL HPLOT,XS,YS,C+8 : CALL HPLOT,XS+1,YS,C+8
+
+320     NEXT XS
+330   NEXT YS
+340 NEXT YI
+
+

--- a/Mandelbrot.txt
+++ b/Mandelbrot.txt
@@ -1,14 +1,15 @@
   1 REM Mandelbrot ported from Applesoft BASIC. Ref: Rosettacode.org
   2 REM Addresses for our four new functions from mapfile:
   3 LET      HGR = $E8B2  : REM F_HGR->init_bitmap_graphics()
-  4 LET    HPLOT = $E8B6  : REM F_HPLOT->draw_pixel()
-  5 LET TEXTMODE = $E8F2  : REM F_TEXT->init_console_text()
-  6 LET     HOME = $E8F6  : REM F_CLS->cls()
+  4 LET    HPLOT = $E8BA : REM F_HPLOT->draw_pixel()
+  5 LET TEXTMODE = $E8F6  : REM F_TEXT->init_console_text()
+  6 LET     HOME = $E8FA  : REM F_CLS->cls()
   7 LET      CLS = HOME   : REM cls()
   8 LET    WHITE = 15     : REM white ON EHBASIC HPLOT. 
   9 REM EhBasic Colorrange 8(grey) 9(red) - 14(cyan) 15(wht); A2 ran 0(blk) - 7(wht2)
 
-10  CALL HGR
+10  REM call HGR with $FF for 320x240x4bpp(4:3); $00 for 320x180x8bpp(16:9) 
+11  CALL HGR,$FF
 20  XC = -0.5           : REM CENTER COORD X
 30  YC = 0              : REM   "      "   Y
 40  S = 2               : REM SCALE
@@ -23,7 +24,8 @@
 120 YM = YR / 191       : REM    "      "     "  Y
 130 FOR YI = 0 TO 3     : REM INTERLEAVE
 140   REM FOR YS = 0+YI TO 188+YI STEP 4 : REM Y SCREEN COORDINATE
-141   FOR YS = 0+YI TO 176+YI STEP 4 : REM EhBASIC y-limit hack
+141   REM FOR YS = 0+YI TO 176+YI STEP 4 : REM EhBASIC y-limit hack $00
+142   FOR YS = 0+YI TO 236+YI STEP 4 : REM EhBASIC y-limit hack $FF
 
 143   REM HCOLOR=3 : REM HPLOT 0,YS TO 279,YS : REM On A2: Clear-to-white 1st
 144   REM On pico6502, unnecessary to 1st clear each line to white

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RP6502 - Enhanced 6502 BASIC
 
-Referfence manual and more information archived here:<br>
+Reference manual and more information archived here:<br>
 http://retro.hansotten.nl/6502-sbc/lee-davison-web-site/enhanced-6502-basic/
 
 You must have on your development system:
@@ -11,3 +11,24 @@ You must have on your development system:
 $ sudo apt-get install cmake python3 pip git build-essential
 $ pip install pyserial
 ```
+
+# Initial plotting enhancements for the RP6502 Picocomputer's EhBASIC
+Enhancements work with (were originally targetted to) the 20-Dec-2023 EhBASIC in the master
+picocomputer repo (rev: 63ca0e6).
+
+Four new commands are available using EhBasic's "CALL" keyword. 
+CALL addresses supplied are from the mapfile. 
+Plotting command is callable from EhBASIC.
+
+The commands are:
+
+    * HGR - initializes the 320h x 180v x 8-bpp mode.
+    * HPLOT,x,y,color - paint a pixel of 'color' at x,y on the screen.
+    * TEXTMODE - return VGA-screen back to console/text mode
+    * CLS (or HOME) - clear the console/text screen.
+
+Assumptions / Limitations:
+
+    * HPLOT targets (only) the 320h x 180v x 8-bit-color mode of the rp6502's pico-VGA.
+    * The x-coordinate from EhBasic is limited to values >= 255 (8-bits). This is a 
+      limitation of parameters following the 'CALL' EhBASIC keyword.

--- a/README.md
+++ b/README.md
@@ -19,16 +19,19 @@ picocomputer repo (rev: 63ca0e6).
 Four new commands are available using EhBasic's "CALL" keyword. 
 CALL addresses supplied are from the mapfile. 
 Plotting command is callable from EhBASIC.
+New: two screen dimensions are supported.
 
 The commands are:
 
-    * HGR - initializes the 320h x 180v x 8-bpp mode.
+    * HGR,screen_dimension - initializes graphics screen mode
+       * CALL HGR,0   - selects 320h x 180v x 8bpp mode (16:9 letterbox);
+       * CALL HGR,$FF - selects 320h x 240v x 4bpp mode (4:3 fullscreen)
     * HPLOT,x,y,color - paint a pixel of 'color' at x,y on the screen.
     * TEXTMODE - return VGA-screen back to console/text mode
     * CLS (or HOME) - clear the console/text screen.
 
 Assumptions / Limitations:
 
-    * HPLOT targets (only) the 320h x 180v x 8-bit-color mode of the rp6502's pico-VGA.
+    * HPLOT targets (only) the two screen-modes listed above on the rp6502's pico-VGA.
     * The x-coordinate from EhBasic is limited to values >= 255 (8-bits). This is a 
       limitation of parameters following the 'CALL' EhBASIC keyword.

--- a/src/basgraf.c
+++ b/src/basgraf.c
@@ -4,7 +4,10 @@
  *
  * Functions:
  * 
- *     init_bitmap_graphics() - Setup bitmap display for 320 x 180 8-bit-per-pixel. 
+ *     init_bitmap_graphics() - Setup bitmap display; clear it. 
+ *                              for either:
+ *                                0x00: 320 x 180  8-bit-per-pixel
+ *                                0xFF: 320 x 240  4-bit-per-pixel
  *         erase_canvas(void) - Clears the bitmapped display.
  *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
  *        init_console_text() - Setup display for console/text; clear it.
@@ -30,25 +33,36 @@
 //   Consider if we may want any of these of global-scope.
 //   Note that draw_pixel() has use for the canvas size too.
 
-static uint16_t canvas_w = 320;     //we are enforcing 320 x 180
-static uint16_t canvas_h = 180;     //we are enforcing 320 x 180
+/* default screen is 320h x 180v x 8bpp unless overriden */
+/* 
+ * Don't use static here in the combined C + EhBASIC environment
+  * statics found to be problematic.  We want to ensure active 
+  * variable initialization at run-time, not only at compile time.
+  * 
+  */
+/*static*/ uint16_t canvas_w = 320;     //we are either 320 x 180 or 320 x 240
+/*static*/ uint16_t canvas_h = 180;     //we are either 320 x 180 or 320 x 240
+/*static*/  uint8_t bpp_mode = 3;       //bits_per_pixel is 8
+/*static*/  uint8_t kr_canvas = 2;      //key-register canvas; either 2 or 1 
+                                    // use-2: 320x180 (16:9) our-original that worked
+                                    // use-1: 320x240 (4:3)
+                                    //other options (don't use for our EhBASIC)
+                                    // use-0 - 80 column console. (4:3 or 5:4)
+                                    // use-3 - 640x480 (4:3)
+                                    // use-4 - 640x360 (16:9)
 
-//static  uint8_t bpp_mode = 3;         /* bits_per_pixel =  8 */
 //static uint16_t canvas_struct = 0xFF00;
 //static uint16_t canvas_data   = 0x0000;
 //static  uint8_t plane = 0;
-//static  uint8_t canvas_mode = 2;
+
 
 
 
 // ---------------------------------------------------------------------------
-// Switch into bitmap-graphics mode, 320x180, 8-bit 256-colors, clear the screen.
+// Switch into selected bitmap-graphics mode, then clear the screen.
 // Can hook this as a 'HGR' command in EhBASIC (reference Applsoft Basic)
-// ntz - in general the entire rp6502 pico-VGA is difficult to understand
-// ntz - hence the comments here.
-// ntz - made void of parameters to ease the c / assembly parameter-calling linkage
 // ---------------------------------------------------------------------------
-void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
+void init_bitmap_graphics( uint8_t dimension /*uint16_t canvas_struct_address,
                           uint16_t canvas_data_address,
                           uint8_t  canvas_plane,
                           uint8_t  canvas_type,
@@ -58,11 +72,13 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
 {
 
     // initializers for the pico-VGA-HW
+
     uint16_t canvas_struct = 0xFF00;
     uint16_t canvas_data   = 0x0000;
     uint8_t  plane = 0;             //from RP6502-VGA docs: we have 3-planes; plane may be: 0, 1 or 2
-    uint8_t  bpp_mode = 3;          /* bits_per_pixel =  8 */
-    uint8_t  canvas_mode = 2;       /* 
+
+ // uint8_t  canvas_mode = 2;       
+                                    /* 
                                      *
                                      * ntz - to-do: I am confused by the 2 vs. 3 here from vruumllc's bitmap library code
                                      *       I believe this should be a 3, not a 2; but is hard-coded 
@@ -76,21 +92,38 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
                                      *      4 - Sprite-mode
                                      *                              
                                      */ 
-                              
-         canvas_w = 320;     //we are enforcing 320 x 180
-         canvas_h = 180;     //we are enforcing 320 x 180
+
 
     /* bits_per_pixel = bpp = (2 ^ bpp_mode), for bpp_modes 0,1,2,3,4 */
     /* pico-VGA-HW needs bpp_mode, not bpp */
     /* we are only coding for our limited BASIC use case: bpp_mode-3, 8-bpp, 256-colors */
 //  bpp_mode = 0; /* bits_per_pixel =  1 */
 //  bpp_mode = 1; /* bits_per_pixel =  2 */
-//  bpp_mode = 2; /* bits_per_pixel =  4 */
-//  bpp_mode = 3; /* bits_per_pixel =  8 */  /* our case */
+//  bpp_mode = 2; /* bits_per_pixel =  4 */  /* our case when 320h x 240v */
+//  bpp_mode = 3; /* bits_per_pixel =  8 */  /* our case when 320h x 180v */
 //  bpp_mode = 4; /* bits_per_pixel = 16 */
 
+/* Don't rely on static compile-time initializations; ensure runtime initializers */
+    canvas_w  = 320;  //we are enforcing 320 width in both screen-size choices
 
-// Other good info to retain for possible code modifications:    
+    canvas_h  = 180;  //default canvas to 180 vertical high
+    bpp_mode  = 3;    //bits_per_pixel is 8; to ensure canvas memory < 64k-bytes
+    kr_canvas = 2;    //use-1: 320x180 (16:9)   
+
+    /* switch screen to 320h x 240v x 4bpp */
+    if (dimension == V240_H320_4BPP ) 
+    {
+         canvas_h  = 240;  //switch canvas to 240 vertical high
+         bpp_mode  = 2;    //bits_per_pixel is 4; to ensure canvas memory < 64k-bytes
+         kr_canvas = 1;    //use-1: 320x240 (4:3)
+//    } else {
+//       canvas_h  = 180;  //switch canvas to 180 vertical high
+//       bpp_mode  = 3;    //bits_per_pixel is 8; to ensure canvas memory < 64k-bytes
+//       kr_canvas = 2;    //use-1: 320x180 (16:9)       
+    } // end if(dimension)
+
+
+// Other good info from Vruumllc's efforts to retain for possible code modifications:    
 //  uint8_t x_offset = 0; //only needed for a bpp_mode=4, when initializing x_pos_px
 //  uint8_t y_offset = 0; //only needed for a bpp_mode=4, when initializing y_pos_px
 //  when bpp_mode==4 set x_offset = 30; /* (360 - 240)/4 */
@@ -119,23 +152,41 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
     }
 #endif /*0*/
 
+#if 0
+    printf("dimension = %x\n", dimension);
+    printf("canvas_w  = %d\n", canvas_w );
+    printf("canvas_h  = %d\n", canvas_h );
+    printf("bpp_mode  = %d\n", bpp_mode);
+    printf("kr_canvas = %d\n", kr_canvas);
+#endif /*0*/
+
+
 
     // initialize the graphics canvas
     //
     //  note: xreg_vga_canvas( /*vargs*/ canvas_mode) is a macro that expands to:
-    //        xreg(1, 0, 0,              canvas_mode)
+    //        xreg(1, 0, 0,              kr_canvas was:canvas_mode)
     //
  // xreg_vga_canvas(canvas_mode);  //nzh: xreg_vga_canvas( /*canvas_mode=*/ 2 );
  // xreg_vga_canvas( /*canvas_mode=*/ 2);
-    xreg(1, 0, 0, 2);
+ // xreg(1, 0, 0, 2); // use-2: 320x180 (16:9) our-original that worked
+                      // use-1: 320x240 (4:3)
+
+                      // other options (don't use for our EhBASIC)
+                      // use-0 - 80 column console. (4:3 or 5:4)
+                      // use-3 - 640x480 (4:3)
+                      // use-4 - 640x360 (16:9)
+
+    xreg(1, 0, 0, kr_canvas);
+
 
     xram0_struct_set(canvas_struct, vga_mode3_config_t, x_wrap, false);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, y_wrap, false);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, x_pos_px,    0 /*x_offset*/);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, y_pos_px,    0 /*y_offset*/);
-    xram0_struct_set(canvas_struct, vga_mode3_config_t, width_px,  320 /*canvas_w*/);
-    xram0_struct_set(canvas_struct, vga_mode3_config_t, height_px, 180 /*canvas_h*/);
-    xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_data_ptr,  canvas_data);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t,  width_px, HSIZE /*canvas_w*/);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, height_px, canvas_h); 
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_data_ptr,    canvas_data);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_palette_ptr, 0xFFFF);
 
     // initialize the bitmap video modes
@@ -148,7 +199,8 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
 //  xreg_vga_mode(3,   bpp_mode,      canvas_struct, plane); // bitmap mode
 //  xreg_vga_mode(3, /*bpp_mode=*/ 3, canvas_struct, plane); // bitmap mode
     /*ntz - note the two '3's here; the 1st 3 was hard-coded in vruumllc's code */
-    xreg(1, 0, 1, 3, 3, canvas_struct, plane);
+//  xreg(1, 0, 1, 3, 3,        canvas_struct, plane);
+    xreg(1, 0, 1, 3, bpp_mode, canvas_struct, plane);
 
 
     erase_canvas(); 
@@ -158,29 +210,36 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
 
 
 // ---------------------------------------------------------------------------
-// Clear the 320 x 180 8-bit-color screen.
-// ntz - in general the entire rp6502 pico-VGA is difficult to understand
-// ntz - hence the comments here.
+// Clear the screen.
+//
+// Screen memory cannot exceed 64kbytes.
+// For 320 x 180 8-bit-color = 320x180   bytes = 57,600 bytes < 64kbytes (good)
+// For 320 x 240 4-bit-color = 320x240/2 bytes = 38,400 bytes < 64kbytes (good) 
+//
 // ---------------------------------------------------------------------------
 void erase_canvas(void)
 {
     uint16_t i;
 //  uint16_t num_bytes;
-    uint16_t loops = 3600; 
+    uint16_t loops = 3600; //        loops       screen       bytes   inline-writes
+                           //default: 3600 for 320x180x8bpp = 57600 / 16-inline-writes-below
+                           //else is: 2400 for 320x240x4bpp = 38400 / 16-inline-writes-below
 
-//Note: for our BASIC special-case: canvas_w = 320 and canvas_h = 180 - always.
-// pre-multiplying: num_bytes = 57600 
+// Note: for our BASIC special-cases: canvas_w = 320 and canvas_h = 180-or-240.
+// pre-multiply the number of screen-bytes.
 
 //    num_bytes = canvas_w * canvas_h;  //note: we may NOT want to optimize this; 
                                         //      easier to support other canvas sizes.
-//    num_bytes = 57600; 
+//    num_bytes = 57600; //for 320x180x8bpp
 
-//  unrolled loop with 16 assignments needed to run num_bytes/16 = 3600 times. 
+//  determine #loops with 16 assignments needed to run num_bytes/16. 
+    if (canvas_h == 240 ) loops = 2400;  
+    
 
 //  RIA.addr0 = canvas_data;  /*canvas_data == 0x0000 for this erase loop*/
     RIA.addr0 = 0x0000;
     RIA.step0 = 1;
-//  for (i = 0; i < (num_bytes/16); i++) { /*num_bytes/16 = 3600 for our special-case*/
+//  for (i = 0; i < (num_bytes/16); i++) {  
     for (i = 0; i < loops; i++) {
         // unrolled for speed
         RIA.rw0 = 0; /* 1*/
@@ -207,7 +266,7 @@ void erase_canvas(void)
 
 // ---------------------------------------------------------------------------
 // Draw a pixel on the RP6502 screen, specifically for 320 x 180 x 8bpp mode.
-// Can hook this as a 'HPLOT' command in EhBASIC using existing 'CALL' keyword.
+// Can hook this as a 'HPLOT' command in EhBASIC
 //
 // ntz - This was challenging: linking the assembly-to-C parameter calling, 
 // ntz -  along with deciphering EhBASIC's parameters following its 'CALL' command.
@@ -220,16 +279,33 @@ void draw_pixel(uint16_t x, uint16_t y, uint16_t color)
 
         /* Ensure unsigned x limited to canvas_w and unsigned y limited to canvas_h */
 
-        x = ((x>319) ? 319 : x);
-        y = ((y>179) ? 179 : y);
+        x = ((x>319) ? 319 : x);  // could use HMAX define here
+        y = ((y>239) ? 239 : y);
+//      y = ((y>179) ? 179 : y);
+        if (canvas_h == 180 ) 
+            y = ((y>179) ? 179 : y);
 
-        //color = GREEN; //test: force green
+/***Begin: our previously demonstrated working case for 320x180x8bpp *****/
+////    RIA.addr0 = canvas_w * y + x;  /* canvas_w always 320 for our EhBASIC canvas */
+////    RIA.addr0 =      320 * y + x; 
+//      RIA.addr0 =    HSIZE * y + x; 
+//      RIA.step0 = 1;
+//      RIA.rw0 = color;  //ntz - note: color is 8-bits for our limited-case; yet is a uint16_t.
+/*****End: our previously demonstrated working case for 320x180x8bpp *****/
 
 
-        RIA.addr0 = canvas_w * y + x;  /* to-do: canvas_w always 320 for our special-case */
-//      RIA.addr0 =      320 * y + x; 
+/* begin: code fragment from Vruumllc with the 'magic' computation for 4bpp */
+    if (bpp_mode == 3) { // 8bpp
+        RIA.addr0 = canvas_w * y + x;  //easy to understand for 8bpp
         RIA.step0 = 1;
-        RIA.rw0 = color;  //ntz - note: color is 8-bits for our limited-case; yet is a uint16_t.
+        RIA.rw0 = color;
+    } else if (bpp_mode == 2) { // 4bpp - requires 'magic' :)
+        uint8_t shift = 4 * (1 - (x & 1));
+        RIA.addr0 = canvas_w/2 * y + x/2;
+        RIA.step0 = 0;
+        RIA.rw0 = (RIA.rw0 & ~(15 << shift)) | ((color & 15) << shift);
+    }
+/* end: Vruumllc 'magic' code-fragment */
 
 } //end draw_pixel()
 
@@ -242,9 +318,11 @@ void draw_pixel(uint16_t x, uint16_t y, uint16_t color)
 void init_console_text(void)
 {
 
-//  xreg_vga_mode(0); // console mode.  Macro expands to: xreg(1, 0, 1, 0);
-    xreg(1, 0, 1, 0); //ntz - difficult to understand 3rd param
-    xreg(1, 0, 0, 0); //ntz - diffucult to understand 4th param
+ // xreg_vga_canvas(0); // or
+    xreg(1, 0, 0, 0);   //kr_canvas = 0 means 80-column console
+
+ // xreg_vga_mode(0); // console mode.  Macro expands to: xreg(1, 0, 1, 0);
+    xreg(1, 0, 1, 0); // kr_mode = 0 means console
 
     // Erase console
 //  printf("\f");

--- a/src/basgraf.c
+++ b/src/basgraf.c
@@ -1,0 +1,268 @@
+/*
+ *
+ * file: basgraf.c
+ *
+ * Functions:
+ * 
+ *     init_bitmap_graphics() - Setup bitmap display for 320 x 180 8-bit-per-pixel. 
+ *         erase_canvas(void) - Clears the bitmapped display.
+ *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
+ *        init_console_text() - Setup display for console/text; clear it.
+ *                      cls() - Clears the console-text display.
+ * 
+ * Note: Based on studying the works of:
+ *        1. Vruumllc of his bitmap_graphics.c/h library and his bitmap_graphics_demo.c. 
+ *        2. Rumbledethumps example-repo files: mode1.c, mode3.c and mandelbrot.c.
+ *        3. Rumbledethumps Picocomputer 6502 Video Graphics Array document.
+ * 
+ */
+
+#include <rp6502.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "basgraf.h"
+
+
+// Parameters need when initializing the pico-VGA HW:
+//   Consider if we may want any of these of global-scope.
+//   Note that draw_pixel() has use for the canvas size too.
+
+static uint16_t canvas_w = 320;     //we are enforcing 320 x 180
+static uint16_t canvas_h = 180;     //we are enforcing 320 x 180
+
+//static  uint8_t bpp_mode = 3;         /* bits_per_pixel =  8 */
+//static uint16_t canvas_struct = 0xFF00;
+//static uint16_t canvas_data   = 0x0000;
+//static  uint8_t plane = 0;
+//static  uint8_t canvas_mode = 2;
+
+
+
+// ---------------------------------------------------------------------------
+// Switch into bitmap-graphics mode, 320x180, 8-bit 256-colors, clear the screen.
+// Can hook this as a 'HGR' command in EhBASIC (reference Applsoft Basic)
+// ntz - in general the entire rp6502 pico-VGA is difficult to understand
+// ntz - hence the comments here.
+// ntz - made void of parameters to ease the c / assembly parameter-calling linkage
+// ---------------------------------------------------------------------------
+void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
+                          uint16_t canvas_data_address,
+                          uint8_t  canvas_plane,
+                          uint8_t  canvas_type,
+                          uint16_t canvas_width,
+                          uint16_t canvas_height,
+                          uint8_t  bits_per_pixel */ )
+{
+
+    // initializers for the pico-VGA-HW
+    uint16_t canvas_struct = 0xFF00;
+    uint16_t canvas_data   = 0x0000;
+    uint8_t  plane = 0;             //from RP6502-VGA docs: we have 3-planes; plane may be: 0, 1 or 2
+    uint8_t  bpp_mode = 3;          /* bits_per_pixel =  8 */
+    uint8_t  canvas_mode = 2;       /* 
+                                     *
+                                     * ntz - to-do: I am confused by the 2 vs. 3 here from vruumllc's bitmap library code
+                                     *       I believe this should be a 3, not a 2; but is hard-coded 
+                                     *       correctly in vruumllc's original with a 3 in the final xreg_vga_mode() call.
+                                     *  
+                                     * canvas_mode may be 1,2,3 or 4; I believe 0 should also be included: 
+                                     *      0 - Console-mode
+                                     *      1 - (Color) Character-mode
+                                     *      2 - Tile-mode
+                                     *      3 - Bit-mapped graphics (our case here)
+                                     *      4 - Sprite-mode
+                                     *                              
+                                     */ 
+                              
+         canvas_w = 320;     //we are enforcing 320 x 180
+         canvas_h = 180;     //we are enforcing 320 x 180
+
+    /* bits_per_pixel = bpp = (2 ^ bpp_mode), for bpp_modes 0,1,2,3,4 */
+    /* pico-VGA-HW needs bpp_mode, not bpp */
+    /* we are only coding for our limited BASIC use case: bpp_mode-3, 8-bpp, 256-colors */
+//  bpp_mode = 0; /* bits_per_pixel =  1 */
+//  bpp_mode = 1; /* bits_per_pixel =  2 */
+//  bpp_mode = 2; /* bits_per_pixel =  4 */
+//  bpp_mode = 3; /* bits_per_pixel =  8 */  /* our case */
+//  bpp_mode = 4; /* bits_per_pixel = 16 */
+
+
+// Other good info to retain for possible code modifications:    
+//  uint8_t x_offset = 0; //only needed for a bpp_mode=4, when initializing x_pos_px
+//  uint8_t y_offset = 0; //only needed for a bpp_mode=4, when initializing y_pos_px
+//  when bpp_mode==4 set x_offset = 30; /* (360 - 240)/4 */
+//  when bpp_mode==4 set y_offset = 29; /* (240 - 124)/4 */
+
+
+#if 0    
+    // valid range check - of inputs to init_bitmap_graphics()
+    if (canvas_struct_address != 0) {
+        canvas_struct = canvas_struct_address;
+    }
+    if (canvas_data_address != 0) {
+        canvas_data = canvas_data_address;
+    }
+    if (/*canvas_plane >= 0 &&*/ canvas_plane <= 2) {
+        plane = canvas_plane;
+    }
+    if (canvas_type > 0 && canvas_type <= 4) {
+        canvas_mode = canvas_type;
+    }
+    if (canvas_width > 0 && canvas_width <= 640) {
+        canvas_w = canvas_width;
+    }
+    if (canvas_height > 0 && canvas_height <= 480) {
+        canvas_h = canvas_height;
+    }
+#endif /*0*/
+
+
+    // initialize the graphics canvas
+    //
+    //  note: xreg_vga_canvas( /*vargs*/ canvas_mode) is a macro that expands to:
+    //        xreg(1, 0, 0,              canvas_mode)
+    //
+ // xreg_vga_canvas(canvas_mode);  //nzh: xreg_vga_canvas( /*canvas_mode=*/ 2 );
+ // xreg_vga_canvas( /*canvas_mode=*/ 2);
+    xreg(1, 0, 0, 2);
+
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, x_wrap, false);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, y_wrap, false);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, x_pos_px,    0 /*x_offset*/);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, y_pos_px,    0 /*y_offset*/);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, width_px,  320 /*canvas_w*/);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, height_px, 180 /*canvas_h*/);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_data_ptr,  canvas_data);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_palette_ptr, 0xFFFF);
+
+    // initialize the bitmap video modes
+    //nzh: bpp_mode==3 for 8-bit-color 
+    //
+    //  note: xreg_vga_mode(          3, bpp_mode, canvas_struct, plane) is a macro that expands to:
+    //        xreg(1, 0, 1, /*vargs*/ 3, bpp_mode, canvas_struct, plane)
+    //  or simply:
+    //        xreg(1, 0, 1, 3, bpp_mode, canvas_struct, plane)   
+//  xreg_vga_mode(3,   bpp_mode,      canvas_struct, plane); // bitmap mode
+//  xreg_vga_mode(3, /*bpp_mode=*/ 3, canvas_struct, plane); // bitmap mode
+    /*ntz - note the two '3's here; the 1st 3 was hard-coded in vruumllc's code */
+    xreg(1, 0, 1, 3, 3, canvas_struct, plane);
+
+
+    erase_canvas(); 
+
+
+} //end init_bitmap_graphics()
+
+
+// ---------------------------------------------------------------------------
+// Clear the 320 x 180 8-bit-color screen.
+// ntz - in general the entire rp6502 pico-VGA is difficult to understand
+// ntz - hence the comments here.
+// ---------------------------------------------------------------------------
+void erase_canvas(void)
+{
+    uint16_t i;
+//  uint16_t num_bytes;
+    uint16_t loops = 3600; 
+
+//Note: for our BASIC special-case: canvas_w = 320 and canvas_h = 180 - always.
+// pre-multiplying: num_bytes = 57600 
+
+//    num_bytes = canvas_w * canvas_h;  //note: we may NOT want to optimize this; 
+                                        //      easier to support other canvas sizes.
+//    num_bytes = 57600; 
+
+//  unrolled loop with 16 assignments needed to run num_bytes/16 = 3600 times. 
+
+//  RIA.addr0 = canvas_data;  /*canvas_data == 0x0000 for this erase loop*/
+    RIA.addr0 = 0x0000;
+    RIA.step0 = 1;
+//  for (i = 0; i < (num_bytes/16); i++) { /*num_bytes/16 = 3600 for our special-case*/
+    for (i = 0; i < loops; i++) {
+        // unrolled for speed
+        RIA.rw0 = 0; /* 1*/
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0; /* 7*/
+        RIA.rw0 = 0; /* 8*/
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0;
+        RIA.rw0 = 0; /*16*/
+    } //end for(i)
+
+} //end erase_canvas()
+
+
+
+// ---------------------------------------------------------------------------
+// Draw a pixel on the RP6502 screen, specifically for 320 x 180 x 8bpp mode.
+// Can hook this as a 'HPLOT' command in EhBASIC using existing 'CALL' keyword.
+//
+// ntz - This was challenging: linking the assembly-to-C parameter calling, 
+// ntz -  along with deciphering EhBASIC's parameters following its 'CALL' command.
+// ntz - NOTE: EhBASIC's parameters following the CALL keyword is limited to bytes only!
+// ntz - This currently is limiting x pixel values to 255 or less from EhBASIC.
+// ---------------------------------------------------------------------------
+void draw_pixel(uint16_t x, uint16_t y, uint16_t color)
+{
+
+
+        /* Ensure unsigned x limited to canvas_w and unsigned y limited to canvas_h */
+
+        x = ((x>319) ? 319 : x);
+        y = ((y>179) ? 179 : y);
+
+        //color = GREEN; //test: force green
+
+
+        RIA.addr0 = canvas_w * y + x;  /* to-do: canvas_w always 320 for our special-case */
+//      RIA.addr0 =      320 * y + x; 
+        RIA.step0 = 1;
+        RIA.rw0 = color;  //ntz - note: color is 8-bits for our limited-case; yet is a uint16_t.
+
+} //end draw_pixel()
+
+
+
+// ---------------------------------------------------------------------------
+// Switch into console/text mode, clear the console.
+// Can hook this as a 'TEXT' or 'TEXTMODE' command in EhBASIC
+// ---------------------------------------------------------------------------
+void init_console_text(void)
+{
+
+//  xreg_vga_mode(0); // console mode.  Macro expands to: xreg(1, 0, 1, 0);
+    xreg(1, 0, 1, 0); //ntz - difficult to understand 3rd param
+    xreg(1, 0, 0, 0); //ntz - diffucult to understand 4th param
+
+    // Erase console
+//  printf("\f");
+    putc(0x0C, stdout);  //send a form-feed (0x0C) to the ansi-compatible VGA console; clears screen.
+
+
+} //end init_console_text() 
+
+
+// ---------------------------------------------------------------------------
+// Clear the console.  Can hook this as a 'HOME' or 'CLS' command in EhBASIC
+// ---------------------------------------------------------------------------
+void cls(void)
+{
+    // Erase console
+//  printf("\f");
+    putc(0x0C, stdout);  //send a form-feed (0x0C) to the ansi-compatible VGA console; clears screen.
+
+} //end cls()
+
+//end-of-file

--- a/src/basgraf.h
+++ b/src/basgraf.h
@@ -1,0 +1,88 @@
+/*
+ *
+ * file: basgraf.h
+ *
+ * Function headers for:
+ * 
+ *     init_bitmap_graphics() - Setup bitmap display for 320 x 180 8-bit-per-pixel; clear it. 
+ *         erase_canvas(void) - Clears the bitmapped display.
+ *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
+ *        init_console_text() - Setup display for console/text; clear it.
+ *                      cls() - Clears the console-text display.
+ *  
+ * 
+ *       Note: Display is much more capable than this implies. As implemented 
+ *             this is the most basic code to establish the
+ *             most basic graphing capability to EhBASIC on the rp6502 SBC. 
+ * 
+ * 
+ */
+
+#ifndef BAS_GRAF_H
+#define BAS_GRAF_H
+
+//#include <stdbool.h>
+#include <stdint.h>
+
+//#define swap(a, b) { int16_t t = a; a = b; b = t; }
+
+
+//From RP6502-VGA docs: the following two macros are only needed for 16-bit color.
+//Since we are limiting our BASIC colors (for now) to 8-bit, these two macros are not needed
+//#define COLOR_FROM_RGB5(r,g,b) (((uint16_t)b<<11)|((uint16_t)g<<6)|((uint16_t)r))
+//#define COLOR_ALPHA_MASK (1u<<5)
+
+/* Define the 8-bit colors for 320x180 mode */
+/*    to be used in the draw_pixel() call   */
+#define RED     0x09
+#define GREEN   0x0A
+#define BLUE    0x0C
+#define WHITE   0x0F
+
+#define YELLOW  0x0B
+#define CYAN    0x0E
+#define MAGENTA 0x0D
+#define LT_GRAY 0x07
+
+
+#if 0 
+/* Declare the 8-bit colors for 320x180 mode */
+uint8_t black        = 0x00
+uint8_t dark_gray    = 0x08
+uint8_t light_gray   = 0x07
+uint8_t white        = 0x0f
+uint8_t red          = 0x09
+uint8_t green        = 0x0a
+uint8_t blue         = 0x0c
+uint8_t yellow       = 0x0b
+uint8_t cyan         = 0x0e
+uint8_t magenta      = 0x0d
+uint8_t dark_red     = 0x01
+uint8_t dark_green   = 0x02
+uint8_t dark_blue    = 0x04
+uint8_t brown        = 0x03
+uint8_t dark_cyan    = 0x06
+uint8_t dark_magenta = 0x05
+#endif /*notdef*/
+
+
+#if 0
+void init_bitmap_graphics(uint16_t canvas_struct_address,
+                          uint16_t canvas_data_address,
+                          uint8_t  canvas_plane,
+                          uint8_t  canvas_type,
+                          uint16_t canvas_width,
+                          uint16_t canvas_height,
+                          uint8_t  bits_per_pixel);
+#endif /*0*/
+
+void init_bitmap_graphics(void);
+void erase_canvas(void);
+void draw_pixel(uint16_t x, uint16_t y, uint16_t color);
+
+void init_console_text(void); 
+void cls(void);
+
+//uint8_t  bits_per_pixel(void);
+
+#endif /* BAS_GRAF_H */

--- a/src/basgraf.h
+++ b/src/basgraf.h
@@ -4,7 +4,10 @@
  *
  * Function headers for:
  * 
- *     init_bitmap_graphics() - Setup bitmap display for 320 x 180 8-bit-per-pixel; clear it. 
+ *     init_bitmap_graphics(dimension) - Setup bitmap display; clear it. 
+ *                              for either:
+ *                                0x00: 320 x 180  8-bit-per-pixel
+ *                                0xFF: 320 x 240  4-bit-per-pixel
  *         erase_canvas(void) - Clears the bitmapped display.
  *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
  *        init_console_text() - Setup display for console/text; clear it.
@@ -76,7 +79,14 @@ void init_bitmap_graphics(uint16_t canvas_struct_address,
                           uint8_t  bits_per_pixel);
 #endif /*0*/
 
-void init_bitmap_graphics(void);
+/* #defines for desired screen dimension */
+#define V180_H320_8BPP 0x00
+#define V240_H320_4BPP 0xFF
+
+#define HSIZE 320 /* always 320 for our use-case */
+#define HMAX  ( HSIZE - 1 ) /* max x-pixel */
+
+void init_bitmap_graphics(uint8_t dimension);
 void erase_canvas(void);
 void draw_pixel(uint16_t x, uint16_t y, uint16_t color);
 

--- a/src/basic.s
+++ b/src/basic.s
@@ -49,6 +49,7 @@
 
 .exportzp LAB_WARM, IrqBase, NmiBase
 .export LAB_COLD, LAB_FCER
+.export LAB_SCGB
 
 .import V_INPT, V_OUTP, V_LOAD, V_SAVE, V_USR
 .import __HEADER_START__, __RAM_START__, __RAM_SIZE__, __STACKSIZE__, __IBUFFSIZE__

--- a/src/rp6502enhance.s
+++ b/src/rp6502enhance.s
@@ -1,0 +1,110 @@
+; File: rp6502enhance.s 
+;
+; Enhancements EhBASIC specific to rp6502 SBC to assemble under CC65
+;
+; Date: 24-Dec-2023
+;
+
+.include "rp6502.inc"
+
+.export F_HGR, F_HPLOT, F_TEXT, F_CLS 
+.export PLOT_XBYT, PLOT_YBYT, PLOT_COLOR
+.import LAB_FCER, LAB_SCGB
+.import _init_bitmap_graphics, _draw_pixel, _init_console_text, _cls
+
+;
+; The following imports from ca65 libraries were difficult to find 
+; but proofed to be key in integrating EnBasci-assembly -> C calling parameters.  
+; This greatly aided parameter/stack prep in using the added EhBasic 'CALL' command 
+; parameters 'HPLOT,x,y,color' prior to call the c-function _plot_pixel().
+; 
+.import pushwysp, staxysp, stax0sp
+
+
+AA_begin_enhancements:
+; Let's show this label in the listing file / mapfile.
+
+; ----------------------------------------------------------------------------
+; New ehanced features added here after AA_end_basic:
+;
+; ntz - force compiler / linker to place these functions defined in C following 
+;       the EhBASIC-interpreter executable code.
+;       For now, they will be CALL'ed via BASIC's 'CALL' command.
+; 
+F_HGR:
+      jmp _init_bitmap_graphics
+      rts ; for safety
+
+F_HPLOT:
+      JSR   LAB_SCGB        ; scan for "," and get byte. Else syntax-error, warm start.
+      STX   PLOT_XBYT       ; save plot x
+      JSR   LAB_SCGB        ; scan for "," and get byte
+      ;;CPX   #$40            ; compare with max+1
+      ;;BCS   PLOT_FCER       ; if 64d or greater do function call error
+      STX   PLOT_YBYT       ; save plot y
+      JSR   LAB_SCGB        ; scan for "," and get byte
+      STX   PLOT_COLOR      ; save color
+
+      ; now tie-in our C-code to perform the HPLOT command: draw_pixel(x,y,color)
+      ; TO-DO: How to get x, y, and color vars on the c-call-stack before calling draw_pixel?...
+      ; Unclear how to get the bytes: PLOT_XBYT, PLOT_YBYT, and PLOT_COLOR
+      ; over to _draw_pixel which (btw) expects uint16_t's.
+
+        ; setup C-stack before calling draw_pixel(x,y,color)
+        ldx #$00              ; x-hi-byte 0; do this as a 8-bit, ignore hi-order-byte
+        lda PLOT_XBYT         ; x-lo-byte valid upto 255 (not 319)
+        ldy #$02
+        jsr staxysp    ; x=PLOT_XBYT
+        lda PLOT_YBYT
+        jsr stax0sp    ; y=PLOT_YBYT
+
+        ;; Example code copied from c-test harness.
+        ;; x = 160; y = 100;
+        ;;
+        ;ldx     #$00
+        ;lda     #$A0
+        ;ldy     #$02
+        ;jsr     staxysp  ; x=160
+        ;lda     #$64
+        ;jsr     stax0sp  ; y=100
+
+
+; Here is working code found by reverse-engr'ing C-code assembly:
+       ldy     #$05
+       jsr     pushwysp  ; x
+       ldy     #$05
+       jsr     pushwysp  ; y
+;       ldx     #$00      ; test-code for forced green
+;       lda     #$0A      ; test-code color forced green, via 'fastcall' convention
+       ldx #$00
+       lda PLOT_COLOR ; stored color, via 'fastcall' convention
+      jmp    _draw_pixel
+      RTS                     ; for safety; or to: return to BASIC
+
+     ; does BASIC function call error
+PLOT_FCER:
+      JMP   LAB_FCER      ; do function call error, then warm start
+      rts ; for safety
+
+    ; now we just need the variable storage for the V_HPLOT / draw_pixel() function.
+PLOT_XBYT:
+        .byte   $00         ; set default x - to-do: needs to be 16-bits since x-max is 319
+PLOT_YBYT:
+        .byte   $00         ; set default y
+PLOT_COLOR:
+        .byte   $0A         ; default to Green
+
+
+F_TEXT:
+      jmp _init_console_text
+      rts ; for safety
+
+F_CLS:
+      jmp _cls
+      rts ; for safety
+
+; Let's show this label in the listing file / mapfile.
+AA_end_enhancements:
+    ; Let keep track of how much code-space we use.
+    ; AA_end_enhancements - AA_begin_enhancements
+    ;

--- a/src/rp6502enhance.s
+++ b/src/rp6502enhance.s
@@ -14,7 +14,7 @@
 
 ;
 ; The following imports from ca65 libraries were difficult to find 
-; but proofed to be key in integrating EnBasci-assembly -> C calling parameters.  
+; but proved to be key in integrating EnBasci-assembly -> C calling parameters.  
 ; This greatly aided parameter/stack prep in using the added EhBasic 'CALL' command 
 ; parameters 'HPLOT,x,y,color' prior to call the c-function _plot_pixel().
 ; 
@@ -31,11 +31,15 @@ AA_begin_enhancements:
 ;       the EhBASIC-interpreter executable code.
 ;       For now, they will be CALL'ed via BASIC's 'CALL' command.
 ; 
-F_HGR:
+F_HGR:      ; HGR now has 1-parameter: dimension-flag 0x00=320x180x8bpp 0xFF=320x240x4bpp
+      JSR   LAB_SCGB        ; scan for "," then get dimension byte in x-reg. 
+                            ; Else syntax-error, warm start.
+      txa                   ; Transfer x-reg to a-reg, our screen-dimension-flag byte
+                            ; before doing our c-call to:
       jmp _init_bitmap_graphics
       rts ; for safety
 
-F_HPLOT:
+F_HPLOT:                    ; HPLOT has 3-parameters: x, y, color 
       JSR   LAB_SCGB        ; scan for "," and get byte. Else syntax-error, warm start.
       STX   PLOT_XBYT       ; save plot x
       JSR   LAB_SCGB        ; scan for "," and get byte

--- a/src/usr.s
+++ b/src/usr.s
@@ -4,6 +4,14 @@
 
 .export V_USR
 .import LAB_FCER
+.import F_HGR, F_HPLOT, F_TEXT, F_CLS 
 
 V_USR:
       JMP LAB_FCER            ; Replace me with your code ("Function call" error)
+
+NewFunc_Tab:
+      .word F_CLS             ; new HOME (or CLS) command -> _cls command 
+      .word F_TEXT            ; new TEXTMODE -> _init_console_text() command
+      .word F_HGR             ; new HGR -> _init_bitmap_graphics() command
+      .word F_HPLOT           ; new HPLOT,x,y,color command
+EndNfTab:


### PR DESCRIPTION
Enhancements work with (were originally targetted to) the 20-Dec-2023 EhBASIC in the master picocomputer repo (rev: 63ca0e6).

Four new commands are available using EhBasic's "CALL" keyword. CALL addresses supplied are from the mapfile. Plotting command is callable from EhBASIC. New: two screen dimensions are supported.

The four commands are:

* HGR,screen_dimension - initializes graphics screen mode
   * CALL HGR,0   - selects 320h x 180v x 8bpp mode (16:9 letterbox);
   * CALL HGR,$FF - selects 320h x 240v x 4bpp mode (4:3 fullscreen)
* HPLOT,x,y,color - paint a pixel of 'color' at x,y on the screen.
* TEXTMODE - return VGA-screen back to console/text mode
* CLS (or HOME) - clear the console/text screen.

Assumptions / Limitations:

* HPLOT targets (only) the two screen-modes listed above on the rp6502's pico-VGA.
* The x-coordinate from EhBasic is limited to values >= 255 (8-bits). This is a 
  limitation of parameters following the 'CALL' EhBASIC keyword.


The additional source files include:

-  basgraf.c/h - the new functions, coded in C
-  rp6502enhance.s - the 'glue' that integrates EhBASIC assembly to four basgraf.c/h functions.

All other EhBasic source remains untouched.
I purposefully did not add the four new commands to EhBasic's command token/system. That additional complexity was not currently needed to demonstrate the concepts. And doing so undoubtedly opens-up additional conversations on syntax, etc.


Two example BASIC programs illustrate the added command features.
The Basic demo/test code includes:

- BarnsleyFern.txt
- Mandelbrot_set - minimal-touch port from Applesoft BASIC listed on [Rosettacode.org](https://rosettacode.org/wiki/Mandelbrot_set)